### PR TITLE
168219775: fix social auth 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1133,6 +1133,11 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "angular-6-social-login": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/angular-6-social-login/-/angular-6-social-login-1.1.1.tgz",
+      "integrity": "sha512-/JCUhzHIRP8I+0m5yWQY3A7HjxgLQPjxLTyjxlQpQ7TEyZhd2Uy1NOvSPnBxODwFwTLnfAyJXlubzssYFhqzdw=="
+    },
     "angularx-social-login": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/angularx-social-login/-/angularx-social-login-1.2.7.tgz",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve -o",
+    "start": "ng serve --host 0.0.0.0 -o",
     "build": "ng build",
-    "test": "ng test --code-coverage",
+    "test": "ng test --code-coverage --watch",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host 0.0.0.0 -o",
+    "start": "ng serve -o",
     "build": "ng build",
     "test": "ng test --code-coverage",
     "lint": "ng lint",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0 -o",
     "build": "ng build",
-    "test": "ng test --code-coverage --watch",
+    "test": "ng test --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,7 +16,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, {useHash: true})],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import {
 } from 'angularx-social-login';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { ErrorInterceptorService } from './shared/interceptors/error-interceptor.service';
+import {SocialAuthComponent} from './components/social-auth/social-auth.component';
 
 const config = new AuthServiceConfig([
   {

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -19,7 +19,7 @@ export class AuthService {
     return this.currentUserSubject.value;
   }
 
-  public signup = (newUser) => this.http.post(`${environment.baseDevUrl}/signup`, newUser).pipe(map( (user: any) => {
+  public signup = (newUser) => this.http.post(`${environment.baseUrl}/signup`, newUser).pipe(map( (user: any) => {
     if (user.token) {
       this.currentUserSubject.next({ username: user.username, token: user.token });
       sessionStorage.setItem(`user`, JSON.stringify(user));

--- a/src/app/auth/signup/signup.component.html
+++ b/src/app/auth/signup/signup.component.html
@@ -1,7 +1,6 @@
 <div class="container">
 <div fxLayout="row" fxLayoutAlign="space-between">
   <img src="/assets/icons/ekalaamu.svg" alt="ekalaamu" />
-  <mat-icon id="close-icon"  routerLink="/">close</mat-icon>
 </div>
 <div fxLayout="column" fxLayoutGap="32px" fxLayoutAlign="center center">
   <form
@@ -12,13 +11,13 @@
   <div class="title">Ekalaamu</div>
   <div class="action">Already have an account? <a href="/auth/login">Log In</a></div>
     <mat-form-field>
-      <input class="form-control" matInput placeholder="First Name"  formControlName="firstname" [errorStateMatcher]="matcher" />
-      <mat-error *ngIf="form.firstname.errors?.required"><strong>* Required</strong> </mat-error>
+      <input class="form-control" matInput placeholder="First Name"  formControlName="firstName" [errorStateMatcher]="matcher" />
+      <mat-error *ngIf="form.firstName.errors?.required"><strong>* Required</strong> </mat-error>
     </mat-form-field>
 
     <mat-form-field>
-      <input class="form-control" matInput placeholder="Last Name" formControlName="lastname" [errorStateMatcher]="matcher" />
-      <mat-error *ngIf="form.lastname.errors?.required"><strong>* Required</strong> </mat-error>
+      <input class="form-control" matInput placeholder="Last Name" formControlName="lastName" [errorStateMatcher]="matcher" />
+      <mat-error *ngIf="form.lastName.errors?.required"><strong>* Required</strong> </mat-error>
     </mat-form-field>
 
     <mat-form-field>

--- a/src/app/auth/signup/signup.component.scss
+++ b/src/app/auth/signup/signup.component.scss
@@ -9,16 +9,6 @@ $ten-px: 10px;
 
 .container {
   padding: 1%;
-
-  #close-icon {
-    outline: none;
-    @include padding();
-    &:hover {
-      background-color: $gray;
-      border-radius: 51%;
-      cursor: pointer;
-    }
-  }
 }
 
 .submit-btn {

--- a/src/app/auth/signup/signup.component.ts
+++ b/src/app/auth/signup/signup.component.ts
@@ -27,11 +27,11 @@ export class SignupComponent implements OnInit {
 
   ngOnInit() {
     this.signupForm = this.formBuilder.group({
-      firstname: ['', Validators.required],
-      lastname: ['', Validators.required],
+      firstName: ['', Validators.required],
+      lastName: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required, Validators.minLength(8)]],
-  });
+    });
 
   }
   get form() { return this.signupForm.controls; }
@@ -44,5 +44,5 @@ export class SignupComponent implements OnInit {
       }
     });
 
-}
+  }
 }

--- a/src/app/components/social-auth/social-auth.component.html
+++ b/src/app/components/social-auth/social-auth.component.html
@@ -1,16 +1,16 @@
 <div fxLayoutAlign="row" class="social-buttons">
   <div class="social-button">
-    <button id="googleBtn" class="googleBtn" mat-mini-fab color="primary" (click)="signInWithGoogle()">
+    <button id="googleBtn" class="googleBtn" mat-fab color="primary" (click)="socialSignIn('google')">
       <mat-icon><img src="../../../assets/icons/search.svg"></mat-icon>
     </button>
   </div>
   <div class="social-button">
-    <button mat-mini-fab color="primary" (click)="signInWithFacebook()">
+    <button id="facebookBtn" mat-fab color="primary" (click)="socialSignIn('facebook')">
       <mat-icon><img src="../../../assets/icons/facebook.svg"></mat-icon>
     </button>
   </div>
   <div class="social-button">
-    <button mat-mini-fab color="primary" (click)="signInWithLinkedIn()">
+    <button id="linkedInBtn" mat-fab color="primary" (click)="socialSignIn('linkedIn')">
       <mat-icon><img src="../../../assets/icons/linkedin.svg"></mat-icon>
     </button>
   </div>

--- a/src/app/components/social-auth/social-auth.component.sass
+++ b/src/app/components/social-auth/social-auth.component.sass
@@ -4,3 +4,7 @@
 
   .social-button
     padding: 5%
+  .mat-fab
+    box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.2), 0px 0px 0px 0px rgba(0, 0, 0, 0.14), 0px 0px 0px 0px rgba(0, 0, 0, 0.12)
+    border: 2px solid rgba(0, 0, 0, 0.12)
+    background: transparent

--- a/src/app/components/social-auth/social-auth.component.spec.ts
+++ b/src/app/components/social-auth/social-auth.component.spec.ts
@@ -5,21 +5,28 @@ import {SharedImports} from '../../utils/test/shared-imports';
 import {AuthService} from 'angularx-social-login';
 import { authServiceSpy, socialAuthServiceSpy } from '../../helpers/tests/spies.spec';
 import {SocialAuthService} from '../../services/social-auth/social-auth.service';
-import {of} from 'rxjs';
+import {of, throwError} from 'rxjs';
 import {triggerEvent} from '../../utils/test/utils';
+import {Router} from '@angular/router';
+import {ToasterService} from '../../shared/services/toaster.service';
 
 describe('SocialAuthComponent', () => {
   let component: SocialAuthComponent;
   let fixture: ComponentFixture<SocialAuthComponent>;
   const sharedImports = new SharedImports();
   let authServiceMock;
+  let toasterService;
+  let toasterServiceErrorSpy;
+  let toasterServiceInfoSpy;
+  let router: Router;
+  let routerSpy;
+  authServiceMock = {
+    ...authServiceSpy,
+    authState: of('user data'),
+    signIn: () => Promise.resolve( 'Arnold' )
+  };
 
   beforeEach(async(() => {
-    authServiceMock = {
-      ...authServiceSpy,
-      authState: of('user data'),
-      signIn: Promise.resolve( 'Arnold' )
-    };
     TestBed.configureTestingModule({
       imports: [...sharedImports.getSharedImports()],
       declarations: [ SocialAuthComponent ],
@@ -32,9 +39,25 @@ describe('SocialAuthComponent', () => {
       .then(() => {
         fixture = TestBed.createComponent(SocialAuthComponent);
         component = fixture.componentInstance;
+        router = TestBed.get(Router);
+        toasterService = TestBed.get(ToasterService);
+        toasterServiceErrorSpy = spyOn(toasterService, 'onFailure');
+        toasterServiceInfoSpy = spyOn(toasterService, 'onInfo');
+        routerSpy = spyOn(router, 'navigate');
+        routerSpy.and.returnValue(null);
         fixture.detectChanges();
       });
   }));
+
+  const setUp = (selector: string): void => {
+    socialAuthServiceSpy.authenticate.and.returnValue(of({firstName: 'test', token: '31trwedhsnadjwydthf'}));
+    const buttonNa = fixture.nativeElement.querySelector(selector);
+    buttonNa.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(routerSpy).toHaveBeenCalled();
+    });
+  }
 
   it('should create', () => {
     expect(component).toBeTruthy();
@@ -42,13 +65,32 @@ describe('SocialAuthComponent', () => {
 
   it('should sign-up user using google', () => {
     // @ts-ignore
-    const spy = spyOn(component, 'signInWithGoogle');
+    setUp('#googleBtn');
+  });
+
+  it('should sign-up user using google', () => {
+    // @ts-ignore
+    setUp('#facebookBtn');
+  });
+
+  it('should display toaster on user sign-up using linkedIn', () => {
+    socialAuthServiceSpy.authenticate.and.returnValue(of({firstName: 'test', token: '31trwedhsnadjwydthf'}));
+    const buttonNa = fixture.nativeElement.querySelector('#linkedInBtn');
+    buttonNa.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(toasterServiceInfoSpy).toHaveBeenCalledWith('Sorry, this service is currently not available');
+    });
+  });
+
+  it('should throw error when something goes wrong', () => {
+    socialAuthServiceSpy.authenticate.and.returnValue(throwError({}));
     const buttonNa = fixture.nativeElement.querySelector('#googleBtn');
     buttonNa.dispatchEvent(new Event('click'));
     fixture.detectChanges();
     fixture.whenStable().then(() => {
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(toasterServiceErrorSpy).toHaveBeenCalledWith('Sorry, an Error occurred');
     });
-
   });
+
 });

--- a/src/app/components/social-auth/social-auth.component.ts
+++ b/src/app/components/social-auth/social-auth.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import {AuthService, FacebookLoginProvider, GoogleLoginProvider, SocialUser} from 'angularx-social-login';
+import {AuthService, FacebookLoginProvider, GoogleLoginProvider, LinkedInLoginProvider, SocialUser} from 'angularx-social-login';
 import { SocialAuthService } from '../../services/social-auth/social-auth.service';
+import {Router} from '@angular/router';
+import {ToasterService} from '../../shared/services/toaster.service';
 
 @Component({
   selector: 'app-social-auth',
@@ -13,7 +15,9 @@ export class SocialAuthComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
-    private socialAuth: SocialAuthService
+    private socialAuth: SocialAuthService,
+    private router: Router,
+    public toaster: ToasterService
   ) { }
 
   ngOnInit() {
@@ -22,37 +26,36 @@ export class SocialAuthComponent implements OnInit {
     });
   }
 
-  signInWithGoogle = (): void => {
-    this.authService.signIn(GoogleLoginProvider.PROVIDER_ID)
-      .then(user => {
-        this.socialAuth.authenticate(user.authToken, 'google-oauth2').subscribe(
-          res => console.log(res),
-          err => console.log(err)
-        );
-      })
-      .catch(err => {
-        console.log(err);
-      });
+  socialSignIn = (socialStrategy: string): void => {
+    switch (socialStrategy) {
+      case 'google':
+        this.socialAuthentication(GoogleLoginProvider.PROVIDER_ID, '/google');
+        break;
+      case 'facebook':
+        this.socialAuthentication(FacebookLoginProvider.PROVIDER_ID, '/facebook');
+        break;
+      default:
+        this.signInWithLinkedIn();
+    }
   }
 
-  signInWithFacebook = () => {
-    this.authService.signIn(FacebookLoginProvider.PROVIDER_ID)
+  socialAuthentication = (strategy: any, route: string): void => {
+    this.authService.signIn(strategy)
       .then(user => {
-        this.socialAuth.authenticate(user.authToken, 'facebook').subscribe(
-          res => console.log(res),
-          err => console.log(err)
+        this.socialAuth.authenticate(user.authToken, route).subscribe(
+          res => {
+            localStorage.setItem('access_token', res.token);
+            this.router.navigate(['/']);
+          },
+          () => {
+            this.toaster.onFailure('Sorry, an Error occurred');
+          }
         );
-      })
-      .catch(err => {
-        console.log(err);
       });
   }
 
   signInWithLinkedIn = () => {
-    this.socialAuth.authenticateLinkedIN().subscribe(
-      res => console.log(res),
-      err => console.log(err)
-    );
+    this.toaster.onInfo('Sorry, this service is currently not available');
   }
 
 }

--- a/src/app/helpers/tests/mock-data.ts
+++ b/src/app/helpers/tests/mock-data.ts
@@ -1,6 +1,16 @@
 export const newUser = {
-  firstname: 'test',
-  lastname: 'user',
+  firstName: 'test',
+  lastName: 'user',
   email: 'test@dev.com',
   password: 'testuser123'
+};
+
+export const authResponse = {
+  access_token: '12wsqadweq23wefrefrdagreggrthygbeythbrtywrrgrgw',
+  firstName: 'test-user'
+};
+
+export const authenticateData = {
+  access_token: '12wsqadweq23wefrefrdagreggrthygbeythbrtywrrgrgw',
+  route: '/google'
 };

--- a/src/app/helpers/tests/spies.spec.ts
+++ b/src/app/helpers/tests/spies.spec.ts
@@ -3,7 +3,7 @@ const createSpyObj = (name: string, methods: string[]) => jasmine.createSpyObj(n
 
 export const routerSpy = createSpyObj('Router', ['navigate']);
 
-export const toasterServiceSpy = createSpyObj('ToasterService', ['onSuccess', 'onFailure']);
+export const toasterServiceSpy = createSpyObj('ToasterService', ['onSuccess', 'onFailure', 'onInfo']);
 
 export const authServiceSpy = createSpyObj('AuthService', [
   'signup', 'currentUserSubject',

--- a/src/app/services/social-auth/social-auth.service.spec.ts
+++ b/src/app/services/social-auth/social-auth.service.spec.ts
@@ -2,6 +2,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { SocialAuthService } from './social-auth.service';
 import {SharedImports} from '../../utils/test/shared-imports';
+import {HttpClient} from '@angular/common/http';
+import {httpClientSpy} from '../../helpers/tests/spies.spec';
+import {authenticateData, authResponse} from '../../helpers/tests/mock-data';
+import {of} from 'rxjs';
 
 
 describe('SocialAuthService', () => {
@@ -10,11 +14,26 @@ describe('SocialAuthService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [...sharedImports.getSharedImports()],
+      providers: [
+        {
+          provide: HttpClient, useValue: httpClientSpy
+        }
+      ]
     });
     service = TestBed.get(SocialAuthService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should authenticate user', () => {
+    httpClientSpy.post.and.returnValue(of(authResponse));
+    service.authenticate('12wsqadweq23wefrefrdagreggrthygbeythbrtywrrgrgw', '/google')
+      .subscribe(
+        value => {
+          expect(value.access_token).toEqual('12wsqadweq23wefrefrdagreggrthygbeythbrtywrrgrgw');
+        }
+      );
   });
 });

--- a/src/app/services/social-auth/social-auth.service.ts
+++ b/src/app/services/social-auth/social-auth.service.ts
@@ -7,26 +7,17 @@ import {environment} from '../../../environments/environment';
 })
 export class SocialAuthService {
   url = environment.baseUrl;
-  client_id = environment.client_id;
-  client_secret = environment.client_secret;
-  callBack = 'http://localhost:4200/social';
 
   constructor(
     private httpClient: HttpClient
   ) { }
 
-  public authenticate = (accessToken: string, backendType: string) => {
+  public authenticate = (accessToken: string, route: string) => {
     return this.httpClient.post<any>(
-      // tslint:disable-next-line:max-line-length
-      `${this.url}convert-token?grant_type=convert_token&client_id=${this.client_id}&client_secret=${this.client_secret}&backend=${backendType}&token=${accessToken}`,
-      {}
-    );
-  }
-
-  authenticateLinkedIN = () => {
-    return this.httpClient.get<any>(
-      // tslint:disable-next-line:max-line-length
-      'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=77aybh4rfe5lig&redirect_uri=http://localhost:4200/auth/callback&state=1qaz2wsx3edc&scope=r_liteprofile%20r_emailaddress%20w_member_social',
+      `${this.url}${route}`,
+      {
+        access_token: accessToken
+      }
     );
   }
 }

--- a/src/app/shared/interceptors/error-interceptor.service.ts
+++ b/src/app/shared/interceptors/error-interceptor.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { Observable, ObservableInput } from 'rxjs';
+import {Observable, ObservableInput, throwError} from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { AuthService } from 'src/app/auth/services/auth.service';
 import { ToasterService } from '../services/toaster.service';
 
 const errorHandler = (toaster: ToasterService) => (error: any, caught: Observable<any>): ObservableInput<any> => {
+  console.log(error);
   toaster.onFailure(error.error.errors[0]);
   return [];
 };

--- a/src/app/shared/services/toaster.service.spec.ts
+++ b/src/app/shared/services/toaster.service.spec.ts
@@ -29,6 +29,11 @@ describe('ToasterService', () => {
     expect(matSnackBarSpy.open).toHaveBeenCalled();
   });
 
+  it('shows info toast', () => {
+    service.onInfo('');
+    expect(matSnackBarSpy.open).toHaveBeenCalled();
+  });
+
   it('shows error toast', () => {
     service.onFailure(toastData.message);
     expect(matSnackBarSpy.open).toHaveBeenCalled();

--- a/src/app/shared/services/toaster.service.ts
+++ b/src/app/shared/services/toaster.service.ts
@@ -7,13 +7,16 @@ import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
 export class ToasterService {
   action = 'close';
   config = {
-     verticalPosition: 'top',
+    verticalPosition: 'top',
+    horizontalPosition: 'right'
   } as MatSnackBarConfig;
 
   constructor(private snackBar: MatSnackBar) {}
 
   onSuccess = (message: string) =>
     this.snackBar.open(message, this.action, {...this.config, panelClass: ['toast-success']})
+  onInfo = (message: string) =>
+    this.snackBar.open(message, this.action, {...this.config, panelClass: ['toast-info']})
   onFailure = (message: string) =>
     this.snackBar.open(message, this.action, {...this.config, panelClass: ['toast-error']})
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,8 +1,7 @@
 export const environment = {
   production: true,
-  baseUrl: 'https://ah-backend-poseidon-staging.herokuapp.com',
+  baseUrl: 'http://localhost:3000/api/v1',
   client_id: 'M0SSqcWMwoJVwg1W6lPF9AVdaYWPgdctzsKjiZ02',
   client_secret: 'CqZLwTrrmf2ijLZyTg95FYhGkeWCiksXIkoDtEmmtOAG8Rg1divZAixp5YDfVnJa' +
-    'zvGyuwlEsGBNziQ11Yz274PJA0WDGSKjoqx5jCmloUMNbO7MNfNSR9JszlLjOare',
-  baseDevUrl: 'http://localhost:3000/api/v1'
+    'zvGyuwlEsGBNziQ11Yz274PJA0WDGSKjoqx5jCmloUMNbO7MNfNSR9JszlLjOare'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,7 +7,7 @@ export const environment = {
   client_id: 'sQ6AHJQxerHLfevr5rywMBFIoy9tpMwiKMbBY94l',
   client_secret: '5M1tXamlOfcBHuyG3BMbp9A0gRp5b701eZs34pYKzWNtvBgWhTRqMj2s' +
     'lUbLDj2S0Df4gv0UP6xjZEHTP5g29EDYjFyXgoAoculwIRn1OLXQieA77cRBbLvGj1oqbhbc',
-  baseUrl: 'https://ah-backend-poseidon-staging.herokuapp.com/api/'
+  baseUrl: 'http://localhost:3000/api/v1'
 };
 
 /*

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -62,10 +62,13 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 .toast-success {
   background-color: #0adc09;
 }
+.toast-info {
+  background-color: #f9cd0b;
+}
 .toast-error {
   background-color: #dc3c09;
 }
-.toast-error, .toast-success {
+.toast-error, .toast-success, .toast-info {
     .mat-simple-snackbar-action {
         color: white !important;
     }


### PR DESCRIPTION
#### What this PR does?
- Fix social login using google and facebook strategies
- write more tests to increase test coverage
- Fix some other small bugs related with user sign-up
- Change the style of the Social auth button to reflect what we have on our mock-up design
#### Description of Task to be completed?
- A user is now able to signup with the system using facebook and google, The user is not able to sign-up with linkedIn and hence an info toaster shows up in case he/she clicks the linkedIn button.
#### How should this be manually tested?
1. Clone the repo using `git clone https://github.com/katunold/ekalaamu.git`
2. Check out to this branch using `git checkout bg-social-auth-168219775`
3. Install all dependencies using `npm i`
4. Run the app using `npm start`
5. In your preferred browser, paste this url `http://localhost:4200/auth/signup`.
6. A signup form with three social auth buttons at the bottom will show up.
7. Before you try signing up with any strategy please ensure that you have the backend api is running locally on your machine.
#### What are the relevant pivotal tracker stories?
[168219775](https://www.pivotaltracker.com/story/show/168219775)
#### Screenshots
![image](https://user-images.githubusercontent.com/25249904/64071859-45cc1080-cc8c-11e9-9593-e834cc582554.png)

